### PR TITLE
Fixes php8 extension build issue, incompatible pointer type

### DIFF
--- a/protobuf-ext/php8/protobuf.c
+++ b/protobuf-ext/php8/protobuf.c
@@ -94,7 +94,7 @@ PHP_METHOD(ProtobufMessage, __construct)
 {
 	zval values_array;
     array_init(&values_array);
-    zend_update_property(pb_entry, getThis(), PB_VALUES_PROPERTY, sizeof(PB_VALUES_PROPERTY) - 1, &values_array);
+    zend_update_property(pb_entry, Z_OBJ_P(ZEND_THIS), PB_VALUES_PROPERTY, sizeof(PB_VALUES_PROPERTY) - 1, &values_array);
 }
 
 PHP_METHOD(ProtobufMessage, append)


### PR DESCRIPTION
A little change to the php8 extension to fix an issue I encountered while building, complaining about the pointer type of the changed argument. Admittedly, I don't know when this started being an issue or what its impact is on other versions in the php 8.x branch. I would advise someone with more experience in these things to verify the proposed solution.

Thanks for this project!